### PR TITLE
Bibtex

### DIFF
--- a/bin/get-bib.py
+++ b/bin/get-bib.py
@@ -4,9 +4,8 @@ import re
 import io
 
 from papers2.schema import Papers2
-db = Papers2(folder="/Users/mxenoph/Library/Application Support/Papers2")
+db = Papers2()
 
-#f = io.open('references.bib', 'w', encoding='utf8')
 f = open(u'references.bib', 'w')
 
 for ind, pub in enumerate(db.get_publications()):
@@ -30,9 +29,7 @@ for ind, pub in enumerate(db.get_publications()):
 	if matching:
 		year, volume, number, pages = matching.groups()
 		pages = re.sub(r'-', '--', pages)
-		title = unicode(pub.title)
 #		title = re.sub(r'\xa0', '', title)
-		print title
 		print >>f, '@articel{%s,\n author={%s},\n title={{%s}},\n journal={%s},\n year={%s},\n volume={%s},\n number={%s},\n pages={%s}\n}\n' % (pub.citekey, formatted_authors, title, pub.bundle_string, year, volume, number, pages)
 	else:
 		print 'No information on year of publication etc'

--- a/bin/get-bib.py
+++ b/bin/get-bib.py
@@ -1,0 +1,40 @@
+#! /bin/env python
+
+import re
+import io
+
+from papers2.schema import Papers2
+db = Papers2(folder="/Users/mxenoph/Library/Application Support/Papers2")
+
+#f = io.open('references.bib', 'w', encoding='utf8')
+f = open(u'references.bib', 'w')
+
+for ind, pub in enumerate(db.get_publications()):
+	print pub.citekey
+	authors = pub.full_author_string.split(',')
+	formatted_authors = ''
+	for i, au in enumerate(authors):
+		if i == (len(authors)-1):
+			au = re.sub(r' and ', '', au)
+		au = re.sub(r'^\s', '', au)
+		au = au.split(' ')
+		first_name = ' '.join(au[:-1])
+		last_name = au[-1]
+		au =  ', '.join([last_name, first_name])
+		if i == 0:
+			formatted_authors = au
+		else:
+			formatted_authors = ' and '.join([formatted_authors, au])
+	pattern = re.compile('(\d+)\s*vol.\s*(\d+)\s*\((\d+)\)\s*pp.(.*)$')
+	matching = pattern.match(pub.publication_string)
+	if matching:
+		year, volume, number, pages = matching.groups()
+		pages = re.sub(r'-', '--', pages)
+		title = unicode(pub.title)
+#		title = re.sub(r'\xa0', '', title)
+		print title
+		print >>f, '@articel{%s,\n author={%s},\n title={{%s}},\n journal={%s},\n year={%s},\n volume={%s},\n number={%s},\n pages={%s}\n}\n' % (pub.citekey, formatted_authors, title, pub.bundle_string, year, volume, number, pages)
+	else:
+		print 'No information on year of publication etc'
+
+f.close()


### PR DESCRIPTION
This is a very hacky solution. 
- At the moment the script will crash if text is formatted in italics/superscript/subscript in the title field.
- Additional testing is required to ensure that the format of the author list is correct for all publications in the library (only tested for a few; not quite sure `pub.full_author_string` is always formatted as first_name, middle_name_initial, last_name). 
  - If a publication is not imported properly the field `pub.publication_string` will not match the pattern for extracting year, volume, number and pages (hence the if-else condition). Need to test the validity of all strings used to make the bib file.
